### PR TITLE
brings back 'Add Another' and 'Delete'

### DIFF
--- a/app/components/LogInputTypes/TimePicker.js
+++ b/app/components/LogInputTypes/TimePicker.js
@@ -47,7 +47,7 @@ export default class TimePicker extends React.Component {
         <Text style={this.state.title_text_style}>{this.state.title_text}</Text>
         <View
           style={{
-            flex: 1,
+            // flex: 1,
             flexDirection: 'row',
             marginBottom: 30,
             paddingLeft: 5


### PR DESCRIPTION
- Played around with styling of MedicineAddForm and found removing the flex:1 styling brings back the 'Add Another' and 'Delete' options for the modal
- Could be a better fix