### PR TITLE
changed indicator time string

### DIFF
--- a/app/components/Card/DoseCard.js
+++ b/app/components/Card/DoseCard.js
@@ -361,7 +361,7 @@ class Card extends PureComponent {
         shouldBeTaken(new Date(val), new Date())
       ) {
         circol = "#fa8b89";
-        taken_string = "Missed";
+        taken_string = shouldBeTakenNow(new Date(val)) ? "Take Now" : "Missed"  ;
       } else {
         circol = "#cccccc";
         taken_string = "Not taken";


### PR DESCRIPTION
fixes #97 
I think both 'Take Now' and 'Missed' should have red color because the green may make it seem like its already taken.